### PR TITLE
study03 - 박세은

### DIFF
--- a/seun/build.gradle
+++ b/seun/build.gradle
@@ -35,6 +35,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testAnnotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'org.projectlombok:lombok'
+	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+	implementation 'javax.xml.bind:jaxb-api:2.3.1'
 }
 
 tasks.named('test') {

--- a/seun/src/main/java/com/study/seun/authorizaiton/controller/TokenApiController.java
+++ b/seun/src/main/java/com/study/seun/authorizaiton/controller/TokenApiController.java
@@ -1,0 +1,25 @@
+package com.study.seun.authorizaiton.controller;
+
+import com.study.seun.authorizaiton.dto.req.CreateAccessTokenRequest;
+import com.study.seun.authorizaiton.dto.res.CreateAccessTokenResponse;
+import com.study.seun.authorizaiton.service.TokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class TokenApiController {
+    private final TokenService tokenService;
+
+    @PostMapping("/api/token")
+    public ResponseEntity<CreateAccessTokenResponse> createNewAccessToken(@RequestBody CreateAccessTokenRequest request){
+        String newAccessToken = tokenService.createNewAccessToken(request.getRefreshToken());
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new CreateAccessTokenResponse(newAccessToken));
+    }
+}

--- a/seun/src/main/java/com/study/seun/authorizaiton/domain/RefreshToken.java
+++ b/seun/src/main/java/com/study/seun/authorizaiton/domain/RefreshToken.java
@@ -1,0 +1,33 @@
+package com.study.seun.authorizaiton.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", updatable = false)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false, unique = true)
+    private Long userId;
+
+    @Column(name = "refresh_token", nullable = false)
+    private String refreshToken;
+
+    public RefreshToken(Long userId, String refreshToken) {
+        this.userId = userId;
+        this.refreshToken = refreshToken;
+    }
+
+    public RefreshToken update(String newRefreshToken) {
+        this.refreshToken = newRefreshToken;
+        return this;
+    }
+}

--- a/seun/src/main/java/com/study/seun/authorizaiton/dto/req/CreateAccessTokenRequest.java
+++ b/seun/src/main/java/com/study/seun/authorizaiton/dto/req/CreateAccessTokenRequest.java
@@ -1,0 +1,10 @@
+package com.study.seun.authorizaiton.dto.req;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CreateAccessTokenRequest {
+    private String refreshToken;
+}

--- a/seun/src/main/java/com/study/seun/authorizaiton/dto/res/CreateAccessTokenResponse.java
+++ b/seun/src/main/java/com/study/seun/authorizaiton/dto/res/CreateAccessTokenResponse.java
@@ -1,0 +1,10 @@
+package com.study.seun.authorizaiton.dto.res;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class CreateAccessTokenResponse {
+    private String accessToken;
+}

--- a/seun/src/main/java/com/study/seun/authorizaiton/repository/RefreshTokenRepository.java
+++ b/seun/src/main/java/com/study/seun/authorizaiton/repository/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package com.study.seun.authorizaiton.repository;
+
+import com.study.seun.authorizaiton.domain.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByUserId(Long userId);
+    Optional<RefreshToken> findByRefreshToken(String refreshToken);
+}

--- a/seun/src/main/java/com/study/seun/authorizaiton/service/RefreshTokenService.java
+++ b/seun/src/main/java/com/study/seun/authorizaiton/service/RefreshTokenService.java
@@ -1,0 +1,17 @@
+package com.study.seun.authorizaiton.service;
+
+import com.study.seun.authorizaiton.domain.RefreshToken;
+import com.study.seun.authorizaiton.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class RefreshTokenService {
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public RefreshToken findByRefreshToken(String refreshToken) {
+        return refreshTokenRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new IllegalArgumentException("Unexpected token"));
+    }
+}

--- a/seun/src/main/java/com/study/seun/authorizaiton/service/TokenService.java
+++ b/seun/src/main/java/com/study/seun/authorizaiton/service/TokenService.java
@@ -1,0 +1,27 @@
+package com.study.seun.authorizaiton.service;
+
+import com.study.seun.authorizaiton.domain.User;
+import com.study.seun.config.jwt.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Service
+public class TokenService {
+
+    private final TokenProvider tokenProvider;
+    private final RefreshTokenService refreshTokenService;
+    private final UserService userService;
+
+    public String createNewAccessToken(String refreshToken) {
+        if(!tokenProvider.validToken(refreshToken)) {
+            throw new IllegalArgumentException("Unexpected token");
+        }
+
+        Long userId = refreshTokenService.findByRefreshToken(refreshToken).getUserId();
+        User user = userService.findById(userId);
+
+        return tokenProvider.generateToken(user, Duration.ofHours(2));
+    }
+}

--- a/seun/src/main/java/com/study/seun/authorizaiton/service/UserService.java
+++ b/seun/src/main/java/com/study/seun/authorizaiton/service/UserService.java
@@ -20,4 +20,9 @@ public class UserService {
                 .password(bCryptPasswordEncoder.encode(dto.getPassword()))
                 .build()).getId();
     }
+
+    public User findById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("Unexpected user"));
+    }
 }

--- a/seun/src/main/java/com/study/seun/config/TokenAuthenticationFilter.java
+++ b/seun/src/main/java/com/study/seun/config/TokenAuthenticationFilter.java
@@ -1,0 +1,45 @@
+package com.study.seun.config;
+
+import com.study.seun.config.jwt.TokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class TokenAuthenticationFilter extends OncePerRequestFilter {
+    private final TokenProvider tokenProvider;
+    private final static String HEADER_AUTHORIZATION = "Authorization";
+    private final static String TOKEN_PREFIX = "Bearer ";
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+
+        String authorizationHeader = request.getHeader(HEADER_AUTHORIZATION);
+
+        String token = getAccessToken(authorizationHeader);
+
+        if(tokenProvider.validToken(token)) {
+            Authentication authentication = tokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getAccessToken(String authorizationHeader) {
+        if(authorizationHeader != null && authorizationHeader.startsWith(TOKEN_PREFIX)) {
+            return authorizationHeader.substring(TOKEN_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/seun/src/main/java/com/study/seun/config/jwt/JwtProperties.java
+++ b/seun/src/main/java/com/study/seun/config/jwt/JwtProperties.java
@@ -1,0 +1,15 @@
+package com.study.seun.config.jwt;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Setter
+@Getter
+@Component
+@ConfigurationProperties("jwt")
+public class JwtProperties {
+    private String issuer;
+    private String secretKey;
+}

--- a/seun/src/main/java/com/study/seun/config/jwt/TokenProvider.java
+++ b/seun/src/main/java/com/study/seun/config/jwt/TokenProvider.java
@@ -1,0 +1,72 @@
+package com.study.seun.config.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Service;
+import com.study.seun.authorizaiton.domain.User;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+
+@RequiredArgsConstructor
+@Service
+public class TokenProvider {
+
+    private final JwtProperties jwtProperties;
+
+    public String generateToken(User user, Duration expiredAt) {
+        Date now = new Date();
+        return makeToken(new Date(now.getTime() + expiredAt.toMillis()), user);
+    }
+
+    private String makeToken(Date expiry, User user) {
+        Date now = new Date();
+
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setIssuer(jwtProperties.getIssuer())
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .setSubject(user.getEmail())
+                .claim("id", user.getId())
+                .signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
+                .compact();
+    }
+
+    public boolean validToken(String token) {
+        try{
+            Jwts.parser()
+                    .setSigningKey(jwtProperties.getSecretKey())
+                    .parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = getClaims(token);
+        Set<SimpleGrantedAuthority> authorities = Collections.singleton(new SimpleGrantedAuthority("ROLE_USER"));
+
+        return new UsernamePasswordAuthenticationToken(new org.springframework.security.core.userdetails.User(claims.getSubject(), "", authorities), token, authorities);
+    }
+
+    public Long getUserId(String token) {
+        Claims claims = getClaims(token);
+        return claims.get("id", Long.class);
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parser()
+                .setSigningKey(jwtProperties.getSecretKey())
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/seun/src/main/resources/application.yml
+++ b/seun/src/main/resources/application.yml
@@ -13,3 +13,6 @@ spring:
     console:
       enabled: true
       path: /h2-console
+jwt:
+  issuer: ajufresh@gmail.com
+  secret_key: study-springboot

--- a/seun/src/test/java/com/study/seun/config/jwt/JwtFactory.java
+++ b/seun/src/test/java/com/study/seun/config/jwt/JwtFactory.java
@@ -1,0 +1,43 @@
+package com.study.seun.config.jwt;
+
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.Builder;
+import lombok.Getter;
+import java.time.Duration;
+import java.util.Date;
+import java.util.Map;
+import static java.util.Collections.emptyMap;
+
+@Getter
+public class JwtFactory {
+    private String subject = "test@email.com";
+    private Date issuedAt = new Date();
+    private Date expiration = new Date(new Date().getTime() + Duration.ofDays(14).toMillis());
+    private Map<String, Object> claims = emptyMap();
+
+    @Builder
+    public JwtFactory(String subject, Date issuedAt, Date expiration, Map<String, Object> claims) {
+        this.subject = subject != null ? subject : this.subject;
+        this.issuedAt = issuedAt != null ? issuedAt : this.issuedAt;
+        this.expiration = expiration != null ? expiration : this.expiration;
+        this.claims = claims != null ? claims : this.claims;
+    }
+
+    public static JwtFactory withDefaultValues() {
+        return JwtFactory.builder().build();
+    }
+
+    public String createToken(JwtProperties jwtProperties) {
+        return Jwts.builder()
+                .setSubject(subject)
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setIssuer(jwtProperties.getIssuer())
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiration)
+                .addClaims(claims)
+                .signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
+                .compact();
+    }
+}

--- a/seun/src/test/java/com/study/seun/config/jwt/TokenProviderTest.java
+++ b/seun/src/test/java/com/study/seun/config/jwt/TokenProviderTest.java
@@ -1,0 +1,96 @@
+package com.study.seun.config.jwt;
+
+import com.study.seun.authorizaiton.domain.User;
+import com.study.seun.authorizaiton.repository.UserRepository;
+import io.jsonwebtoken.Jwts;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.Map;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@SpringBootTest
+public class TokenProviderTest {
+    @Autowired
+    private TokenProvider tokenProvider;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private JwtProperties jwtProperties;
+
+    @DisplayName("generateToken() : 유저 정보와 만료 기간을 전달해 토큰을 만들 수 있다.")
+    @Test
+    void generateToken() {
+        User testUser = userRepository.save(User.builder()
+                .email("user@gmail.com")
+                .password("test")
+                .build());
+
+        String token = tokenProvider.generateToken(testUser, Duration.ofDays(14));
+
+        Long userId = Jwts.parser()
+                .setSigningKey(jwtProperties.getSecretKey())
+                .parseClaimsJws(token)
+                .getBody()
+                .get("id", Long.class);
+
+        assertThat(userId).isEqualTo(testUser.getId());
+    }
+
+    @DisplayName("validToken() : 만료된 토큰인 때에 유효성 검증에 실패한다.")
+    @Test
+    void validToken_invalidToken(){
+        String token = JwtFactory.builder()
+                .expiration(new Date(new Date().getTime() - Duration.ofDays(7).toMillis()))
+                .build()
+                .createToken(jwtProperties);
+
+        boolean result = tokenProvider.validToken(token);
+        assertThat(result).isFalse();
+    }
+
+    @DisplayName("vaildToken() : 유효한 토큰인 때에 유효성 검증에 성공한다.")
+    @Test
+    void validToken_validToken(){
+        String token = JwtFactory.withDefaultValues().createToken(jwtProperties);
+
+        boolean result = tokenProvider.validToken(token);
+
+        assertThat(result).isTrue();
+    }
+
+    @DisplayName("getAuthentication() : 토큰 기반으로 인증 정보를 가져올 수 있다.")
+    @Test
+    void getAuthentication(){
+        String userEmail = "user@email.com";
+        String token = JwtFactory.builder()
+                .subject(userEmail)
+                .build()
+                .createToken(jwtProperties);
+
+        Authentication authentication = tokenProvider.getAuthentication(token);
+
+        assertThat(((UserDetails) authentication.getPrincipal()).getUsername()).isEqualTo(userEmail);
+    }
+
+    @DisplayName("getUserId() : 토큰으로 유저 ID를 가져올 수 있다.")
+    @Test
+    void getUserId(){
+        Long userId = 1L;
+        String token = JwtFactory.builder()
+                .claims(Map.of("id", userId))
+                .build()
+                .createToken(jwtProperties);
+
+        Long userIdByToken = tokenProvider.getUserId(token);
+
+        assertThat(userIdByToken).isEqualTo(userId);
+    }
+}

--- a/seun/src/test/java/com/study/seun/controller/TokenApiControllerTest.java
+++ b/seun/src/test/java/com/study/seun/controller/TokenApiControllerTest.java
@@ -1,0 +1,81 @@
+package com.study.seun.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.study.seun.authorizaiton.domain.RefreshToken;
+import com.study.seun.authorizaiton.domain.User;
+import com.study.seun.authorizaiton.dto.req.CreateAccessTokenRequest;
+import com.study.seun.authorizaiton.repository.RefreshTokenRepository;
+import com.study.seun.authorizaiton.repository.UserRepository;
+import com.study.seun.config.jwt.JwtFactory;
+import com.study.seun.config.jwt.JwtProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import java.util.Map;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class TokenApiControllerTest {
+    @Autowired
+    protected MockMvc mockMvc;
+    @Autowired
+    protected ObjectMapper objectMapper;
+    @Autowired
+    private WebApplicationContext context;
+    @Autowired
+    UserRepository userRepository;
+    @Autowired
+    RefreshTokenRepository refreshTokenRepository;
+    @Autowired
+    private JwtProperties jwtProperties;
+
+    @BeforeEach
+    public void mockMvcSetUp() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .build();
+        userRepository.deleteAll();
+    }
+
+    @DisplayName("createNewAccessToken : 새로운 액세스 토큰을 발급한다.")
+    @Test
+    public void createNewAccessToken() throws Exception {
+        final String url = "/api/token";
+
+        User testUser = userRepository.save(User.builder()
+                .email("user@gmal.com")
+                .password("test")
+                .build());
+
+        String refreshToken = JwtFactory.builder()
+                .claims(Map.of("id", testUser.getId()))
+                .build()
+                .createToken(jwtProperties);
+
+        refreshTokenRepository.save(new RefreshToken(testUser.getId(), refreshToken));
+
+        CreateAccessTokenRequest request = new CreateAccessTokenRequest();
+        request.setRefreshToken(refreshToken);
+
+        final String requestBody = objectMapper.writeValueAsString(request);
+
+        ResultActions resultActions = mockMvc.perform(post(url)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(requestBody));
+
+        resultActions
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.accessToken").isNotEmpty());
+    }
+
+}


### PR DESCRIPTION
## ✅ 진도 체크

- 스프링부트3 백엔드개발자되기 9장 실습 완료
<br>

## 스터디원들에게 공유하고 싶은 내용

### SecurityContext
- security context는 인증 객체가 저장되는 보관소 
- 인증 정보가 필요할 때 언제든지 인증 객체를 꺼내 사용 가능
- 스레드마다 공간을 할당하는 **thread local**에 저장되므로 코드의 아무 곳에서나 참조할 수 있다.
- 따라서 다른 스레드와 공유하지 않으므로 독립적으로 사용할 수 있다.
- 이런 security context 객체를 저장하는 객체가 **security context holder**이다.
<br>

### SecurityContextHolder
- Security Context 객체 저장 방식
    -  **MODE_THREADLOCAL**
        - thread 당 SecurityContext 객체를 할당, 기본값이다.
        - 자식 스레드와는 공유가 되지 않는다. 공유를 하려면 아래 모드로 변환
    - **MODE_INHERITABLETHREADLOCAL** 
        - 메인 스레드와 자식 스레드에 관하여 동일한 SecurityContext를 유지
    - **MODE_GLOBAL** 
        - 응용 프로그램에서 단 하나의 SecurityContext를 저장
- 객체 저장 방식은 보안 설정 클래스에서 변경 가능
`SecurityContextHolder.setStrategyName(SecurityContextHolder.MODE_INHERITABLETHREADLOCAL)`
- `SecurityContextHolder.clearContext()`
    - ecurityContext 기존 정보 초기화 코드
<br>

### SecurityContextPersistenceFilter
- SecurityContext 객체의 생성, 저장, 조회하는 필터
1. 익명 사용자
   - 새로운 SecurityContext 객체를 생성하여 SecurityContextHolder에 저장
   - AnonmousAuthenticationFilter에서 AnonymousAuthenticationToken 객체를 SecurityContext에 저장한다.
2. 인증 시
   - 새로운 SecurityContext 객체를 생성하여 SecurityContextHolder에 저장
   - UsernamePasswordAuthenticationFilter에서 인증 성공 후 UsernamePasswordAuthenticationToken 객체를 SecurityContext에 저장
   - 인증이 최종 완료되면 Session에 SecurityContext를 저장
3. 인증 후
   - Session에서 SecurityContext를 꺼내에 SecurityContextHolder에 저장
   - SecurityContext 안에 Authentication 객체가 존재하면 계속 인증을 유지
4. 최종 응답 시 공통
   - SecurityContextHolder.clearContext()
<br>

### 헷갈리는 어노테이션
- `@ConfigurationProperties` 
    - 자바 클래스에 프로피티값을 가져와서 사용 
    - **애플리케이션의 설정 정보를 자바 클래스로 바인딩하는 데 사용**

- `@Component`
    - 개발자가 직접 작성한 클래스를 Bean 으로 만드는 것 

- `@Configuration`
    - 해당 클래스에서 1개 이상의 Bean을 생성하고 있음을 명시

- `@Autowired`  
    - field , setter, method, constructor에서 사용하며 Type에 따라 자동으로 bean을 주입
    - Type을 먼저 확인하여 못 찾는 경우에는 name에 따라서 bean을 주입
    -  이때 해당 타입의 bean 객체가 존재하지 않거나, 2개 이상 존재할 경우 스프링은 예외가 발생

- `@Bean`
    - 개발자가 직접 제어가 불가능한 외부 라이브러리 등을 Bean으로 만들려고 할 때 사용
<br>


## 참고 블로그
[스프링 시큐리티 관련 블로그](https://velog.io/@gmtmoney2357/%EC%8A%A4%ED%94%84%EB%A7%81-%EC%8B%9C%ED%81%90%EB%A6%AC%ED%8B%B0-Authentication-SecurityContext)
[어노테이션 관련 블로그](https://wildeveloperetrain.tistory.com/26)

