### PR TITLE
study03 - 유하영

### DIFF
--- a/youhayeong/springboot-developer2/build.gradle
+++ b/youhayeong/springboot-developer2/build.gradle
@@ -35,10 +35,25 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    // 테스트 롬복 의존성 추가
+    testCompileOnly 'org.projectlombok:lombok'
+    testAnnotationProcessor 'org.projectlombok:lombok'
+
     // spring security
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     testImplementation 'org.springframework.security:spring-security-test'
+
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt:0.9.1'
+    implementation 'javax.xml.bind:jaxb-api:2.3.1'
+
+    // jwt 최신 라이브러리
+    /*
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    implementation 'io.jsonwebtoken:jjwt:0.12.6'
+    */
 }
 
 tasks.named('test') {

--- a/youhayeong/springboot-developer2/src/main/java/org/springbootdeveloper2/config/jwt/JwtProperties.java
+++ b/youhayeong/springboot-developer2/src/main/java/org/springbootdeveloper2/config/jwt/JwtProperties.java
@@ -1,0 +1,16 @@
+package org.springbootdeveloper2.config.jwt;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component // 해당 클래스를 빈으로 등록하여 의존성 주입이 가능하도록 함
+@ConfigurationProperties("jwt") // yml에서 'jwt'로 시작하는 설정 값을 자동으로 매핑
+public class JwtProperties {
+    // yml 파일에서 설정한 값들이 매핑됨
+    private String issuer;
+    private String secretKey;
+}

--- a/youhayeong/springboot-developer2/src/main/java/org/springbootdeveloper2/config/jwt/TokenAuthenticationFilter.java
+++ b/youhayeong/springboot-developer2/src/main/java/org/springbootdeveloper2/config/jwt/TokenAuthenticationFilter.java
@@ -1,0 +1,45 @@
+package org.springbootdeveloper2.config.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class TokenAuthenticationFilter extends OncePerRequestFilter {
+
+    private final TokenProvider tokenProvider;
+    private final static String HEADER_AUTHORIZATION = "Authorization";
+    private final static String TOKEN_PREFIX = "Bearer ";
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+
+        // 요청 헤더의 authorization 키의 값 조회
+        String authorizationHeader = request.getHeader(HEADER_AUTHORIZATION);
+
+        // 가져온 값에서 헤더 제거
+        String token = getAccessToken(authorizationHeader);
+
+        // 가져온 토큰의 유효성 검사 후, 유효하다면 인증 정보 설정
+        if (tokenProvider.validToken(token)) {
+            Authentication authentication = tokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+        filterChain.doFilter(request, response);
+    }
+    private String getAccessToken(String authorizationHeader) {
+        if (authorizationHeader != null && authorizationHeader.startsWith(TOKEN_PREFIX)) {
+            return authorizationHeader.substring(TOKEN_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/youhayeong/springboot-developer2/src/main/java/org/springbootdeveloper2/config/jwt/TokenProvider.java
+++ b/youhayeong/springboot-developer2/src/main/java/org/springbootdeveloper2/config/jwt/TokenProvider.java
@@ -1,0 +1,82 @@
+package org.springbootdeveloper2.config.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import org.springbootdeveloper2.domain.User;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Set;
+
+@RequiredArgsConstructor
+@Service
+public class TokenProvider {
+    // 토큰 생성, 유효성 검사, 토큰에서 필요한 정보를 가져오는 클래스
+    // 사용자 인증을 처리하는 비즈니스 로직 포함 o = @Service 어노테이션
+
+    private final JwtProperties jwtProperties;
+
+    public String generateToken(User user, Duration expiredAt) {
+        Date now = new Date();
+        return makeToken(new Date(now.getTime() + expiredAt.toMillis()), user);
+    }
+
+    // 1. JWT 토큰 생성 메서드
+    private String makeToken(Date expiry, User user) {
+        Date now = new Date();
+
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE) // 헤더 typ: "JWT"
+                .setIssuer(jwtProperties.getIssuer()) // 내용 iss: yml에서 매핑
+                .setIssuedAt(now)   // 내용 iat: 현재 시간
+                .setExpiration(expiry)  // 내용 exp: expiry 멤버 변수값
+                .setSubject(user.getEmail())    // 내용 sub: 유저 이메일
+                .claim("id", user.getId())  // 클레임 id: 유저 id
+                .signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
+                // 서명: 비밀값과 함께 해시값을 HS256 방식으로 암호화
+                .compact(); // 압축해서 토큰 생성
+    }
+
+    // 2. JWT 토큰 유효성 검증 메서드
+    public boolean validToken(String token) {
+        try {
+            Jwts.parser()
+                    .setSigningKey(jwtProperties.getSecretKey())    // 비밀값으로 복호화
+                    .parseClaimsJws(token);
+
+            return true;
+        } catch (Exception e) {
+            return false; // 유효하지 않은 토큰
+        }
+    }
+
+    // 3. 토큰 기반으로 인증 정보 가져오는 메서드
+    public Authentication getAuthentication(String token) {
+        Claims claims = getClaims(token); // 토큰에서 클레임 정보 추출
+        Set<SimpleGrantedAuthority> authorities = Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")); // 권한 설정
+        return new UsernamePasswordAuthenticationToken(new org.springframework.security.core.userdetails.User(claims.getSubject
+                (), "", authorities), token, authorities);
+    }
+
+    // 4. 토큰 기반으로 유저 id 가져오는 메서드
+    public Long getUserId(String token) {
+        Claims claims = getClaims(token);
+        return claims.get("id", Long.class);
+    }
+
+    // 3 - 토큰에서 클레임 정보 추출 메서드
+    private Claims getClaims(String token) {
+        return Jwts.parser()
+                .setSigningKey(jwtProperties.getSecretKey())
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/youhayeong/springboot-developer2/src/main/java/org/springbootdeveloper2/controller/TokenApiController.java
+++ b/youhayeong/springboot-developer2/src/main/java/org/springbootdeveloper2/controller/TokenApiController.java
@@ -1,0 +1,26 @@
+package org.springbootdeveloper2.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springbootdeveloper2.dto.request.CreateAccessTokenRequest;
+import org.springbootdeveloper2.dto.response.CreateAccessTokenResponse;
+import org.springbootdeveloper2.service.TokenService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TokenApiController {
+
+    private final TokenService tokenService;
+
+    @PostMapping("/api/token")
+    public ResponseEntity<CreateAccessTokenResponse> createNewAccessToken
+            (@RequestBody CreateAccessTokenRequest request) {
+        String newAccessToken = tokenService.createNewAccessToken(request.getRefreshToken());
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(new CreateAccessTokenResponse(newAccessToken));
+    }
+}

--- a/youhayeong/springboot-developer2/src/main/java/org/springbootdeveloper2/domain/RefreshToken.java
+++ b/youhayeong/springboot-developer2/src/main/java/org/springbootdeveloper2/domain/RefreshToken.java
@@ -1,0 +1,32 @@
+package org.springbootdeveloper2.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Entity
+public class RefreshToken {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id", updatable = false)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false, unique = true)
+    private Long userId;
+
+    @Column(name = "refresh_token", nullable = false)
+    private String refreshToken;
+
+    public RefreshToken(Long userId, String refreshToken) {
+        this.userId = userId;
+        this.refreshToken = refreshToken;
+    }
+
+    public RefreshToken update(String newRefreshToken) {
+        this.refreshToken = newRefreshToken;
+        return this;
+    }
+}

--- a/youhayeong/springboot-developer2/src/main/java/org/springbootdeveloper2/dto/request/CreateAccessTokenRequest.java
+++ b/youhayeong/springboot-developer2/src/main/java/org/springbootdeveloper2/dto/request/CreateAccessTokenRequest.java
@@ -1,0 +1,10 @@
+package org.springbootdeveloper2.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CreateAccessTokenRequest {
+    private String refreshToken;
+}

--- a/youhayeong/springboot-developer2/src/main/java/org/springbootdeveloper2/dto/response/CreateAccessTokenResponse.java
+++ b/youhayeong/springboot-developer2/src/main/java/org/springbootdeveloper2/dto/response/CreateAccessTokenResponse.java
@@ -1,0 +1,10 @@
+package org.springbootdeveloper2.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CreateAccessTokenResponse {
+    private String accessToken;
+}

--- a/youhayeong/springboot-developer2/src/main/java/org/springbootdeveloper2/repository/RefreshTokenRepository.java
+++ b/youhayeong/springboot-developer2/src/main/java/org/springbootdeveloper2/repository/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package org.springbootdeveloper2.repository;
+
+import org.springbootdeveloper2.domain.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByUserId(Long userId);
+    Optional<RefreshToken> findByRefreshToken(String refreshToken);
+}

--- a/youhayeong/springboot-developer2/src/main/java/org/springbootdeveloper2/service/RefreshTokenService.java
+++ b/youhayeong/springboot-developer2/src/main/java/org/springbootdeveloper2/service/RefreshTokenService.java
@@ -1,0 +1,19 @@
+package org.springbootdeveloper2.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springbootdeveloper2.domain.RefreshToken;
+import org.springbootdeveloper2.repository.RefreshTokenRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    // 전달 받은 리프레시 토큰으로 리프레시 토큰 객체를 검색해서 전달하는 메서드
+    public RefreshToken findByRefreshToken(String refreshToken) {
+        return refreshTokenRepository.findByRefreshToken(refreshToken).orElseThrow(
+                () -> new IllegalArgumentException("Unexpected token"));
+    }
+}

--- a/youhayeong/springboot-developer2/src/main/java/org/springbootdeveloper2/service/TokenService.java
+++ b/youhayeong/springboot-developer2/src/main/java/org/springbootdeveloper2/service/TokenService.java
@@ -1,0 +1,34 @@
+package org.springbootdeveloper2.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springbootdeveloper2.config.jwt.TokenProvider;
+import org.springbootdeveloper2.domain.User;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Service
+public class TokenService {
+
+    private final TokenProvider tokenProvider;
+    private final RefreshTokenService refreshTokenService;
+    private final UserService userService;
+
+    // 전달 받은 리프레시 토큰으로 토큰 유효성 검사 -> 유효한 토큰일 때 사용자 id 찾기 -> generateNewToken
+    public String createNewAccessToken(String refreshToken) {
+        // 토큰 유효성 검사
+        if(!tokenProvider.validToken(refreshToken)) {
+            throw new IllegalArgumentException("Unexpected token");
+        }
+
+        // 리프레시 토큰으로 사용자 id 찾기
+        Long userId = refreshTokenService.findByRefreshToken(refreshToken).getUserId();
+
+        // userId로 사용자 찾아서 user 객체 생성
+        User user = userService.findById(userId);
+
+        // 토큰 제공자의 generateToken으로 새로운 액세스 토큰 생성
+        return tokenProvider.generateToken(user, Duration.ofHours(2));
+    }
+}

--- a/youhayeong/springboot-developer2/src/main/java/org/springbootdeveloper2/service/UserService.java
+++ b/youhayeong/springboot-developer2/src/main/java/org/springbootdeveloper2/service/UserService.java
@@ -22,4 +22,10 @@ public class UserService {
                 .password(bCryptPasswordEncoder.encode(addUserRequest.getPassword()))
                 .build()).getId();
     }
+
+    // 전달 받은 유저 id로 유저 검색해서 전달
+    public User findById(Long userId) {
+        return userRepository.findById(userId).orElseThrow(
+                () -> new IllegalArgumentException("Unexpected user"));
+    }
 }

--- a/youhayeong/springboot-developer2/src/main/resources/application.yml
+++ b/youhayeong/springboot-developer2/src/main/resources/application.yml
@@ -16,3 +16,7 @@ spring:
       hibernate:
         format_sql: false
         use_sql_comments: true
+
+jwt:
+  issuer: ${jwt.issuer}
+  secret_key: ${jwt.secret_key}

--- a/youhayeong/springboot-developer2/src/test/java/org/springbootdeveloper2/config/jwt/JwtFactory.java
+++ b/youhayeong/springboot-developer2/src/test/java/org/springbootdeveloper2/config/jwt/JwtFactory.java
@@ -1,0 +1,51 @@
+package org.springbootdeveloper2.config.jwt;
+
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.Builder;
+import lombok.Getter;
+
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.Map;
+
+import static java.util.Collections.emptyMap;
+
+@Getter
+public class JwtFactory {
+
+    private String subject = "test@email.com";
+
+    private Date issuedAt = new Date();
+
+    private Date expiration = new Date(new Date().getTime() + Duration.ofDays(14).toMillis());
+
+    private Map<String, Object> claims = emptyMap();
+
+    @Builder
+    public JwtFactory(String subject, Date issuedAt, Date expiration,
+                      Map<String, Object> claims) {
+        this.subject = subject != null ? subject : this.subject;
+        this.issuedAt = issuedAt != null ? issuedAt : this.issuedAt;
+        this.expiration = expiration != null ? expiration : this.expiration;
+        this.claims = claims != null ? claims : this.claims;
+    }
+
+    public static JwtFactory withDefaultValues() {
+        return JwtFactory.builder().build();
+    }
+
+    public String createToken(JwtProperties jwtProperties) {
+        return Jwts.builder()
+                .setSubject(subject)
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE)
+                .setIssuer(jwtProperties.getIssuer())
+                .setIssuedAt(issuedAt)
+                .setExpiration(expiration)
+                .addClaims(claims)
+                .signWith(SignatureAlgorithm.HS256, jwtProperties.getSecretKey())
+                .compact();
+    }
+}

--- a/youhayeong/springboot-developer2/src/test/java/org/springbootdeveloper2/config/jwt/TokenProviderTest.java
+++ b/youhayeong/springboot-developer2/src/test/java/org/springbootdeveloper2/config/jwt/TokenProviderTest.java
@@ -1,0 +1,118 @@
+package org.springbootdeveloper2.config.jwt;
+
+import io.jsonwebtoken.Jwts;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springbootdeveloper2.domain.User;
+import org.springbootdeveloper2.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.time.Duration;
+import java.util.Date;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class TokenProviderTest {
+
+    @Autowired
+    private TokenProvider tokenProvider;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private JwtProperties jwtProperties;
+
+    @DisplayName("generateToken(): 유저 정보와 만료 기간을 전달해 토큰을 만들 수 있다.")
+    @Test
+    void generateToken() {
+        // given - 토큰에 유저 정보를 추가하기 위한 테스트 유저 생성
+        User testUser = userRepository.save(User.builder()
+                .email("user@gmail.com")
+                .password("test")
+                .build());
+
+        // when - 토큰 생성
+        String token = tokenProvider.generateToken(testUser, Duration.ofDays(14));
+
+        // then - 토큰 복호화, id 값이 given에서 만든 유저 id와 동일한지 검증
+        Long userId = Jwts.parser()
+                .setSigningKey(jwtProperties.getSecretKey())
+                .parseClaimsJws(token)
+                .getBody()
+                .get("id", Long.class);
+
+        assertThat(userId).isEqualTo(testUser.getId());
+    }
+
+    @DisplayName("validToken(): 만료된 토큰인 경우에 유효성 검증에 실패한다.")
+    @Test
+    void validToken_invalidToken() {
+        // given - 이미 만료된 토큰으로 생성
+        String token = JwtFactory.builder()
+                .expiration(new Date(new Date().getTime() - Duration.ofDays(7).toMillis()))
+                .build()
+                .createToken(jwtProperties);
+
+        // when - 토큰 검증
+        boolean result = tokenProvider.validToken(token);
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+
+    @DisplayName("validToken(): 유효한 토큰인 경우에 유효성 검증에 성공한다.")
+    @Test
+    void validToken_validToken() {
+        // given - 토큰 생성
+        String token = JwtFactory.withDefaultValues()
+                .createToken(jwtProperties);
+
+        // when - 토큰 검증
+        boolean result = tokenProvider.validToken(token);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+
+    @DisplayName("getAuthentication(): 토큰 기반으로 인증정보를 가져올 수 있다.")
+    @Test
+    void getAuthentication() {
+        // given - 토큰 생성
+        String userEmail = "user@email.com";
+        String token = JwtFactory.builder()
+                .subject(userEmail)
+                .build()
+                .createToken(jwtProperties);
+
+        // when - 인증 객체 반환
+        Authentication authentication = tokenProvider.getAuthentication(token);
+
+        // then - 반환받은 인증 객체의 유저 이름을 가져와 given에서 설정한 subject 값과 일치한지 확인
+        assertThat(((UserDetails) authentication.getPrincipal()).getUsername()).isEqualTo(userEmail);
+    }
+
+    @DisplayName("getUserId(): 토큰으로 유저 ID를 가져올 수 있다.")
+    @Test
+    void getUserId() {
+        // given - 클레임 추가하여 토큰 생성, 키는 "id", 값은 1이라는 유저 id
+        Long userId = 1L;
+        String token = JwtFactory.builder()
+                .claims(Map.of("id", userId))
+                .build()
+                .createToken(jwtProperties);
+
+        // when - 유저 id 반환
+        Long userIdByToken = tokenProvider.getUserId(token);
+
+        // then
+        assertThat(userIdByToken).isEqualTo(userId);
+    }
+}

--- a/youhayeong/springboot-developer2/src/test/java/org/springbootdeveloper2/controller/TokenApiControllerTest.java
+++ b/youhayeong/springboot-developer2/src/test/java/org/springbootdeveloper2/controller/TokenApiControllerTest.java
@@ -1,0 +1,92 @@
+package org.springbootdeveloper2.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springbootdeveloper2.config.jwt.JwtFactory;
+import org.springbootdeveloper2.config.jwt.JwtProperties;
+import org.springbootdeveloper2.domain.RefreshToken;
+import org.springbootdeveloper2.domain.User;
+import org.springbootdeveloper2.dto.request.CreateAccessTokenRequest;
+import org.springbootdeveloper2.repository.RefreshTokenRepository;
+import org.springbootdeveloper2.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.Map;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class TokenApiControllerTest {
+
+    @Autowired
+    protected MockMvc mockMvc;
+
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    @Autowired
+    JwtProperties jwtProperties;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    RefreshTokenRepository refreshTokenRepository;
+
+    @BeforeEach
+    public void mockMvcSetUp() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+                .build();
+        userRepository.deleteAll();
+    }
+
+    @DisplayName("createNewAccessToken: 새로운 액세스 토큰을 발급한다.")
+    @Test
+    public void createNewAccessToken() throws Exception {
+        // given
+        final String url = "/api/token";
+
+        User testUser = userRepository.save(User.builder()
+                .email("user@gmail.com")
+                .password("test")
+                .build());
+
+        String refreshToken = JwtFactory.builder()
+                .claims(Map.of("id", testUser.getId()))
+                .build()
+                .createToken(jwtProperties);
+
+        refreshTokenRepository.save(new RefreshToken(testUser.getId(), refreshToken));
+
+        CreateAccessTokenRequest request = new CreateAccessTokenRequest();
+        request.setRefreshToken(refreshToken);
+        final String requestBody = objectMapper.writeValueAsString(request);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(post(url)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content(requestBody));
+
+        // then
+        resultActions
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.accessToken").isNotEmpty());
+    }
+
+}


### PR DESCRIPTION
## ✅ 진도 체크

도서 어디까지 학습했는지 적어주세요.

- 스프링 부트 3 백엔드 개발자 되기: 자바 편
- ch9 JWT로 로그인/ 로그아웃 구현하기

## 스터디원들에게 공유하고 싶은 내용

공부하면서 의문을 가졌던 점, 추가로 공부했던 점, 스터디원들이 알았으면 하는 점, 혹은 함께 토론하고자 하는 내용이 있으면 적어주세요.

### - 리프레시 토큰이 필요한 이유에 대한 이해
![image](https://github.com/user-attachments/assets/7c2318d3-890f-4757-8197-eb6aa47a812e)

[Refresh Token 사용 이유](https://puleugo.tistory.com/154)
[access&refresh 토큰 원리](https://inpa.tistory.com/entry/WEB-%F0%9F%93%9A-Access-Token-Refresh-Token-%EC%9B%90%EB%A6%AC-feat-JWT)
<hr>

### - TestCode에서 package lombok does not exist 에러
![image](https://github.com/user-attachments/assets/eaa58748-65a8-4038-8ce8-75f4293fbfde)
- 테스트 환경에서는 롬복 사용을 위해 아래 의존성을 추가해줘야 함
![image](https://github.com/user-attachments/assets/2802249e-1d03-4a38-923f-bcf80fa0a74b)

### - Library plugin dependency

1. `complileOnly` - 컴파일 시에만 사용
2. `api` - api 대신 implementation 권장
3. `implementation` - 해당 모듈 내부에서만 의존할 때 사용
4. `runtimeOnly` - 런타임에만 사용
5. `testComplileOnly` - 테스트 컴파일 시점에만 필요하지만 런타임에 누출되어서는 안 되는 의존성 선언
6. `testImplementation` - 테스트 컴파일할 때 필요한 의존성에 설정
7. `testRuntimeOnly` - 테스트 런타임에만 필요할 경우 설정
8. `annotationProcessor` - 컴파일 단계에서 해당 의존성이 동작하도록 활성화

[java library plugin](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph)
[의존성 설정](https://earth-95.tistory.com/216)
<hr>

### - JWT 0.12.6 버전으로 했을 때 해당 프로젝트 TokenProvider 오류
![image](https://github.com/user-attachments/assets/1885d4df-edc9-4334-aec1-0858fdf85577)
- 해당 프로젝트는 jjwt 0.9.1 사용, 최신 라이브러리인 0.12.6 적용시 호환성 오류

### - JWT 0.9.x → 0.12.6 버전 바뀐 점
1. `Jwts.parser()` → `Jwts.parserBuilder()`
2. `setSigningKey(...)` → `verifyWith(...)`
3. `parseClaimsJws()` → `parseSignedClaims()`
4. `getBody()` → `getPayload()`
5. `signWith(SignatureAlgorithm, secretKey)` → `signWith(Key, SignatureAlgorithm)`
6. `setHeaderParam(...)` → `header().type(...).and()`

[maven 라이브러리 찾기](https://mvnrepository.com/)
[jjwt 0.11.2에서 0.12.5 마이그레이션](https://moonsiri.tistory.com/206)
